### PR TITLE
Rebuild pipeline if failed

### DIFF
--- a/libs/gllm-plugin/gllm_plugin/pipeline/pipeline_handler.py
+++ b/libs/gllm-plugin/gllm_plugin/pipeline/pipeline_handler.py
@@ -221,7 +221,56 @@ class PipelineHandler(PluginHandler):
         Raises:
             ValueError: If the chatbot ID is invalid or the model name is not supported.
         """
+        if chatbot_id not in self._builders:
+            logger.warning(f"Pipeline builder not found for chatbot `{chatbot_id}`, attempting to rebuild...")
+            # Try to rebuild the plugin if it's not found
+            self._try_rebuild_plugin(chatbot_id)
+            
+        if chatbot_id not in self._builders:
+            raise ValueError(f"Pipeline builder for chatbot `{chatbot_id}` not found and could not be rebuilt")
+            
         return self._builders[chatbot_id]
+
+    def _try_rebuild_plugin(self, chatbot_id: str) -> None:
+        """Try to rebuild a plugin for the given chatbot.
+
+        Args:
+            chatbot_id (str): The chatbot ID.
+        """
+        try:
+            # Check if we have the chatbot configuration
+            if chatbot_id not in self._chatbot_configs:
+                logger.error(f"Chatbot configuration not found for `{chatbot_id}`")
+                return
+
+            chatbot_config = self._chatbot_configs[chatbot_id]
+            pipeline_type = chatbot_config.pipeline_type
+            
+            # Check if we have the plugin for this pipeline type
+            if pipeline_type not in self._plugins:
+                logger.error(f"Plugin not found for pipeline type `{pipeline_type}`")
+                return
+
+            plugin = self._plugins[pipeline_type]
+            
+            # Get supported models from the configuration
+            supported_models = list(chatbot_config.pipeline_config.get("supported_models", {}).values())
+            
+            if not supported_models:
+                logger.warning(f"No supported models found for chatbot `{chatbot_id}`")
+                return
+
+            # Rebuild the plugin synchronously (this is a simplified version)
+            # Set the catalogs
+            plugin.prompt_builder_catalogs = chatbot_config.prompt_builder_catalogs
+            plugin.lmrp_catalogs = chatbot_config.lmrp_catalogs
+            self._builders[chatbot_id] = plugin
+            
+            logger.info(f"Successfully rebuilt pipeline builder for chatbot `{chatbot_id}`")
+            
+        except Exception as e:
+            logger.error(f"Error rebuilding plugin for chatbot `{chatbot_id}`: {e}")
+            pass
 
     def get_pipeline(self, chatbot_id: str, model_name: str) -> Pipeline:
         """Get a pipeline instance for the given chatbot and model name.
@@ -236,7 +285,144 @@ class PipelineHandler(PluginHandler):
         Raises:
             ValueError: If the chatbot ID is invalid.
         """
-        return self._pipeline_cache[(chatbot_id, str(model_name))]
+        pipeline_key = (chatbot_id, str(model_name))
+        
+        if pipeline_key not in self._pipeline_cache:
+            logger.warning(f"Pipeline not found for chatbot `{chatbot_id}` model `{model_name}`, attempting to rebuild...")
+            # Try to rebuild the pipeline if it's not found
+            self._try_rebuild_pipeline(chatbot_id, model_name)
+            
+        if pipeline_key not in self._pipeline_cache:
+            raise ValueError(f"Pipeline for chatbot `{chatbot_id}` model `{model_name}` not found and could not be rebuilt")
+            
+        return self._pipeline_cache[pipeline_key]
+
+    def _try_rebuild_pipeline(self, chatbot_id: str, model_name: str) -> None:
+        """Try to rebuild a pipeline for the given chatbot and model.
+
+        Args:
+            chatbot_id (str): The chatbot ID.
+            model_name (str): The model name.
+        """
+        try:
+            # First, ensure we have the pipeline builder
+            if chatbot_id not in self._builders:
+                self._try_rebuild_plugin(chatbot_id)
+                
+            if chatbot_id not in self._builders:
+                logger.error(f"Could not rebuild pipeline builder for chatbot `{chatbot_id}`")
+                return
+
+            # Check if we have the chatbot configuration
+            if chatbot_id not in self._chatbot_configs:
+                logger.error(f"Chatbot configuration not found for `{chatbot_id}`")
+                return
+
+            chatbot_config = self._chatbot_configs[chatbot_id]
+            plugin = self._builders[chatbot_id]
+            
+            # Find the model configuration
+            supported_models = list(chatbot_config.pipeline_config.get("supported_models", {}).values())
+            model_config = None
+            
+            for model in supported_models:
+                if model.get("name") == model_name:
+                    model_config = model
+                    break
+                    
+            if not model_config:
+                logger.error(f"Model `{model_name}` not found in supported models for chatbot `{chatbot_id}`")
+                return
+
+            # Build the pipeline configuration
+            pipeline_config = chatbot_config.pipeline_config.copy()
+            pipeline_config["model_name"] = model_name
+            pipeline_config["model_kwargs"] = model_config.get("model_kwargs", {})
+            pipeline_config["model_env_kwargs"] = model_config.get("model_env_kwargs", {})
+            
+            # for backward compatibility
+            credentials = pipeline_config["model_env_kwargs"].get("credentials")
+            if credentials:
+                pipeline_config["api_key"] = credentials
+
+            # Note: This is a simplified rebuild that doesn't actually build the pipeline
+            # since the original _build_plugin method is async and we're in a sync context
+            # The actual pipeline building would need to be done asynchronously
+            logger.warning(f"Pipeline rebuild for chatbot `{chatbot_id}` model `{model_name}` requires async context")
+            
+        except Exception as e:
+            logger.error(f"Error rebuilding pipeline for chatbot `{chatbot_id}` model `{model_name}`: {e}")
+            pass
+
+    async def _async_rebuild_pipeline(self, chatbot_id: str, model_name: str) -> None:
+        """Asynchronously rebuild a pipeline for the given chatbot and model.
+
+        Args:
+            chatbot_id (str): The chatbot ID.
+            model_name (str): The model name.
+        """
+        try:
+            # Check if we have the chatbot configuration
+            if chatbot_id not in self._chatbot_configs:
+                logger.error(f"Chatbot configuration not found for `{chatbot_id}`")
+                return
+
+            chatbot_config = self._chatbot_configs[chatbot_id]
+            pipeline_type = chatbot_config.pipeline_type
+            
+            # Check if we have the plugin for this pipeline type
+            if pipeline_type not in self._plugins:
+                logger.error(f"Plugin not found for pipeline type `{pipeline_type}`")
+                return
+
+            plugin = self._plugins[pipeline_type]
+            
+            # Find the model configuration
+            supported_models = list(chatbot_config.pipeline_config.get("supported_models", {}).values())
+            model_config = None
+            
+            for model in supported_models:
+                if model.get("name") == model_name:
+                    model_config = model
+                    break
+                    
+            if not model_config:
+                logger.error(f"Model `{model_name}` not found in supported models for chatbot `{chatbot_id}`")
+                return
+
+            # Use the existing _build_plugin method to rebuild the pipeline
+            await __class__._build_plugin(self, chatbot_id, [model_config], plugin)
+            
+            logger.info(f"Successfully rebuilt pipeline for chatbot `{chatbot_id}` model `{model_name}`")
+            
+        except Exception as e:
+            logger.error(f"Error rebuilding pipeline for chatbot `{chatbot_id}` model `{model_name}`: {e}")
+            pass
+
+    async def aget_pipeline(self, chatbot_id: str, model_name: str) -> Pipeline:
+        """Get a pipeline instance for the given chatbot and model name (async version).
+
+        Args:
+            chatbot_id (str): The chatbot ID.
+            model_name (str): The model to use for inference.
+
+        Returns:
+            Pipeline: The pipeline instance.
+
+        Raises:
+            ValueError: If the chatbot ID is invalid.
+        """
+        pipeline_key = (chatbot_id, str(model_name))
+        
+        if pipeline_key not in self._pipeline_cache:
+            logger.warning(f"Pipeline not found for chatbot `{chatbot_id}` model `{model_name}`, attempting to rebuild...")
+            # Try to rebuild the pipeline if it's not found
+            await self._async_rebuild_pipeline(chatbot_id, model_name)
+            
+        if pipeline_key not in self._pipeline_cache:
+            raise ValueError(f"Pipeline for chatbot `{chatbot_id}` model `{model_name}` not found and could not be rebuilt")
+            
+        return self._pipeline_cache[pipeline_key]
 
     def get_pipeline_config(self, chatbot_id: str) -> dict[str, Any]:
         """Get the pipeline configuration by chatbot ID.
@@ -433,3 +619,63 @@ class PipelineHandler(PluginHandler):
         """
         if chatbot_id not in self._chatbot_configs:
             raise ValueError(f"Pipeline configuration for chatbot `{chatbot_id}` not found")
+
+    async def aget_pipeline_builder(self, chatbot_id: str) -> Plugin:
+        """Get a pipeline builder instance for the given chatbot (async version).
+
+        Args:
+            chatbot_id (str): The chatbot ID.
+
+        Returns:
+            Plugin: The pipeline builder instance.
+
+        Raises:
+            ValueError: If the chatbot ID is invalid or the model name is not supported.
+        """
+        if chatbot_id not in self._builders:
+            logger.warning(f"Pipeline builder not found for chatbot `{chatbot_id}`, attempting to rebuild...")
+            # Try to rebuild the plugin if it's not found
+            await self._async_rebuild_plugin(chatbot_id)
+            
+        if chatbot_id not in self._builders:
+            raise ValueError(f"Pipeline builder for chatbot `{chatbot_id}` not found and could not be rebuilt")
+            
+        return self._builders[chatbot_id]
+
+    async def _async_rebuild_plugin(self, chatbot_id: str) -> None:
+        """Asynchronously rebuild a plugin for the given chatbot.
+
+        Args:
+            chatbot_id (str): The chatbot ID.
+        """
+        try:
+            # Check if we have the chatbot configuration
+            if chatbot_id not in self._chatbot_configs:
+                logger.error(f"Chatbot configuration not found for `{chatbot_id}`")
+                return
+
+            chatbot_config = self._chatbot_configs[chatbot_id]
+            pipeline_type = chatbot_config.pipeline_type
+            
+            # Check if we have the plugin for this pipeline type
+            if pipeline_type not in self._plugins:
+                logger.error(f"Plugin not found for pipeline type `{pipeline_type}`")
+                return
+
+            plugin = self._plugins[pipeline_type]
+            
+            # Get supported models from the configuration
+            supported_models = list(chatbot_config.pipeline_config.get("supported_models", {}).values())
+            
+            if not supported_models:
+                logger.warning(f"No supported models found for chatbot `{chatbot_id}`")
+                return
+
+            # Use the existing _build_plugin method to rebuild the plugin
+            await __class__._build_plugin(self, chatbot_id, supported_models, plugin)
+            
+            logger.info(f"Successfully rebuilt pipeline builder for chatbot `{chatbot_id}`")
+            
+        except Exception as e:
+            logger.error(f"Error rebuilding plugin for chatbot `{chatbot_id}`: {e}")
+            pass

--- a/libs/gllm-plugin/tests/unit/test_pipeline_handler.py
+++ b/libs/gllm-plugin/tests/unit/test_pipeline_handler.py
@@ -351,12 +351,12 @@ def test_get_pipeline_builder_success(pipeline_handler: PipelineHandler):
 def test_get_pipeline_builder_not_found(pipeline_handler: PipelineHandler):
     """
     Condition:
-    - chatbot_id not in _builders
+    - chatbot_id not in _builders and rebuild fails
 
     Expected:
-    - Raises KeyError
+    - Raises ValueError with descriptive message
     """
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError, match="Pipeline builder for chatbot `nonexistent` not found and could not be rebuilt"):
         pipeline_handler.get_pipeline_builder("nonexistent")
 
 
@@ -379,12 +379,12 @@ def test_get_pipeline_success(pipeline_handler: PipelineHandler):
 def test_get_pipeline_not_found(pipeline_handler: PipelineHandler):
     """
     Condition:
-    - Pipeline key not in cache
+    - Pipeline key not in cache and rebuild fails
 
     Expected:
-    - Raises KeyError
+    - Raises ValueError with descriptive message
     """
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError, match="Pipeline for chatbot `chatbot1` model `nonexistent_model` not found and could not be rebuilt"):
         pipeline_handler.get_pipeline("chatbot1", "nonexistent_model")
 
 
@@ -433,7 +433,7 @@ def test_get_pipeline_type_not_found(pipeline_handler: PipelineHandler):
     - chatbot_id not in _chatbot_configs
 
     Expected:
-    - Raises KeyError
+    - Raises KeyError (direct dictionary access)
     """
     with pytest.raises(KeyError):
         pipeline_handler.get_pipeline_type("nonexistent")


### PR DESCRIPTION
### Tested locally with scenario:
1. Use this branch for GLChat BE toml: `gllm-plugin = {git = "ssh://git@github.com/GDP-ADMIN/gen-ai-external.git", subdirectory = "libs/gllm-plugin", branch = "e/rebuild-pipeline-if-failed"}`
2. `make run-dependencies` and kill elasticsearch.
3. `make run` will start the app and all pipeline failed (expected can't connect ES).
4. `make run-dependencies` again to start elasticsearch.
5. curl message:
```bash
curl -X POST "http://localhost:8000/message" \
     -H "Accept-Language: en-US" \
     -H "Content-Type: application/x-www-form-urlencoded" \
     --data-urlencode "user_id=username" \
     --data-urlencode "chatbot_id=general-purpose" \
     --data-urlencode "message=Hola"
```
6. chatbot will be rebuilt and can answer the user query.

### Need feedbacks:
1. Since want to reuse _build_plugin function to rebuild, GLChat need to use aget_pipeline in `pipeline_runner`.
2. In GLChat `pipeline_runner`, 2nd param passed as` ModelName` not `str` and show warning in Pycharm IDE. Need to change `pipeline_handler` line 377 with cast as `str(model_name)`.

This pull request introduces enhancements to error handling and adds functionality for rebuilding pipeline builders and pipelines in the `PipelineHandler` class. Key changes include the addition of async methods for plugin and pipeline rebuilding, improved logging for debugging, and mechanisms to recover from missing configurations or cache entries.

### Error Handling and Debugging Enhancements:
* Added `traceback` import and improved logging with `traceback.format_exc()` to provide detailed error stack traces during plugin initialization and pipeline building. (`[[1]](diffhunk://#diff-c2a2c39b77074c2217741551ddca1f61596f9fe87bff3d68419708d7995e665cL21-R21)`, `[[2]](diffhunk://#diff-c2a2c39b77074c2217741551ddca1f61596f9fe87bff3d68419708d7995e665cR156)`, `[[3]](diffhunk://#diff-c2a2c39b77074c2217741551ddca1f61596f9fe87bff3d68419708d7995e665cR210)`)

### Plugin and Pipeline Recovery Mechanisms:
* Introduced `_try_rebuild_plugin` and `_async_rebuild_plugin` methods to rebuild missing pipeline builders synchronously and asynchronously. These methods handle scenarios where chatbot configurations or plugins are unavailable. (`[[1]](diffhunk://#diff-c2a2c39b77074c2217741551ddca1f61596f9fe87bff3d68419708d7995e665cR226-R276)`, `[[2]](diffhunk://#diff-c2a2c39b77074c2217741551ddca1f61596f9fe87bff3d68419708d7995e665cR611-R670)`)
* Added `_try_rebuild_pipeline` and `_async_rebuild_pipeline` methods to recover pipelines for specific chatbot IDs and model names. These methods ensure compatibility with supported models and configurations. (`[libs/gllm-plugin/gllm_plugin/pipeline/pipeline_handler.pyL239-R414](diffhunk://#diff-c2a2c39b77074c2217741551ddca1f61596f9fe87bff3d68419708d7995e665cL239-R414)`)
* Created `aget_pipeline` and `aget_pipeline_builder` async methods to retrieve pipelines and builders, incorporating recovery logic for missing entries. (`[[1]](diffhunk://#diff-c2a2c39b77074c2217741551ddca1f61596f9fe87bff3d68419708d7995e665cL239-R414)`, `[[2]](diffhunk://#diff-c2a2c39b77074c2217741551ddca1f61596f9fe87bff3d68419708d7995e665cR611-R670)`)