### PR TITLE
[INFRA] Temporary self-hosted to github runner

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -32,6 +32,12 @@ jobs:
         python-version: ${{ fromJson(needs.Set-Python-Version-Matrix.outputs.matrix) }}
     continue-on-error: true
     steps:
+    - name: Clean workspace
+      shell: bash
+      run: |
+        echo "GITHUB_WORKSPACE: $GITHUB_WORKSPACE"
+        rm -rf $GITHUB_WORKSPACE/*
+
     - uses: actions/checkout@v4
 
     - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-sh-arm64, macos-sh-x64]
+        os: [windows-latest, macos-sh-arm64, macos-13]
         python-version: ${{ fromJson(needs.Set-Python-Version-Matrix.outputs.matrix) }}
     continue-on-error: true
     steps:
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [windows-latest, macos-sh-arm64, macos-sh-x64]
+        os: [windows-latest, macos-sh-arm64, macos-13]
         python-version: ${{ fromJson(needs.Set-Python-Version-Matrix.outputs.matrix) }}
     permissions:
       id-token: write


### PR DESCRIPTION
### Tested
https://github.com/GDP-ADMIN/glchat-sdk/actions/runs/16310169754 (expected error `Unable to find installation candidates for bosa-core-binary (0.5.4)` because that package is not provided in pypi)
https://pypi.org/project/gllm-plugin-binary/0.1.7b1/#files
<img width="819" height="361" alt="image" src="https://github.com/user-attachments/assets/ad1e5fff-4590-469e-9a3c-2d1971adeb23" />
