### PR TITLE
[GLLM Plugin] Remove Add User/AI Abstract Method

### DIFF
--- a/libs/gllm-plugin/gllm_plugin/storage/base_chat_history_storage.py
+++ b/libs/gllm-plugin/gllm_plugin/storage/base_chat_history_storage.py
@@ -137,42 +137,6 @@ class BaseChatHistoryStorage(ABC):
         pass
 
     @abstractmethod
-    def add_user_message(self, message: str, user_id: str, conversation_id: str, 
-                        parent_id: str | None = None, source: str | None = None, **kwargs: Any) -> Message:
-        """Add a user message to a conversation.
-
-        Args:
-            message (str): The message content.
-            user_id (str): The ID of the user.
-            conversation_id (str): The ID of the conversation.
-            parent_id (str | None, optional): The ID of the parent message. Defaults to None.
-            source (str | None, optional): The source of the message. Defaults to None.
-            kwargs (Any): Additional arguments.
-
-        Returns:
-            Message: The added message.
-        """
-        pass
-
-    @abstractmethod
-    def add_ai_message(self, message: str, user_id: str, conversation_id: str,
-                      parent_id: str | None = None, source: str | None = None, **kwargs: Any) -> Message:
-        """Add an AI message to a conversation.
-
-        Args:
-            message (str): The message content.
-            user_id (str): The ID of the user.
-            conversation_id (str): The ID of the conversation.
-            parent_id (str | None, optional): The ID of the parent message. Defaults to None.
-            source (str | None, optional): The source of the message. Defaults to None.
-            kwargs (Any): Additional arguments.
-
-        Returns:
-            Message: The added message.
-        """
-        pass
-
-    @abstractmethod
     def save_message(self, user_id: str, conversation_id: str, message_list: list[Any],
                     attachments: dict[str, Any] | None, **kwargs: Any) -> list[Message]:
         """Save a list of messages to a conversation.


### PR DESCRIPTION
### Overview

This removes an unused message-storing method from the abstract. The Chat history manager from GLLM Misc module already supports adding user and AI messages in one call using `store`. Since messages are always paired, individual storage is redundant and we can lazily persist message pairs to the database.
