### PR TITLE
feat (BE): add BaseRateLimiterService

### DIFF
--- a/python/glchat-plugin/glchat_plugin/service/base_rate_limiter_service.py
+++ b/python/glchat-plugin/glchat_plugin/service/base_rate_limiter_service.py
@@ -15,10 +15,12 @@ class BaseRateLimiterService(ABC):
     """A base class for tenant service."""
 
     @abstractmethod
-    async def custom_identifier(self, **kwargs: Any) -> str:
+    async def custom_identifier(self, request: Any, identifier_id: Any, **kwargs: Any) -> str:
         """Abstract method to get a custom identifier for rate limiting.
 
         Args:
+            request (Request): The incoming request.
+            identifier_id (str): The identifier ID for rate limiting.
             **kwargs (Any): Additional keyword arguments.
 
         Returns:
@@ -28,10 +30,11 @@ class BaseRateLimiterService(ABC):
 
 
     @abstractmethod
-    async def setup_rate_limiter(self, **kwargs: Any) -> None:
+    async def setup_rate_limiter(self, redis_client: Any, **kwargs: Any) -> None:
         """Abstract method to set up the rate limiter.
 
         Args:
+            redis_client (Any): The Redis client instance.
             **kwargs (Any): Additional keyword arguments.
         """
         raise NotImplementedError

--- a/python/glchat-plugin/glchat_plugin/service/base_rate_limiter_service.py
+++ b/python/glchat-plugin/glchat_plugin/service/base_rate_limiter_service.py
@@ -30,11 +30,10 @@ class BaseRateLimiterService(ABC):
 
 
     @abstractmethod
-    async def setup_rate_limiter(self, redis_client: Any, **kwargs: Any) -> None:
+    async def setup_rate_limiter(self, **kwargs: Any) -> None:
         """Abstract method to set up the rate limiter.
 
         Args:
-            redis_client (Any): The Redis client instance.
             **kwargs (Any): Additional keyword arguments.
         """
         raise NotImplementedError

--- a/python/glchat-plugin/glchat_plugin/service/base_rate_limiter_service.py
+++ b/python/glchat-plugin/glchat_plugin/service/base_rate_limiter_service.py
@@ -28,12 +28,23 @@ class BaseRateLimiterService(ABC):
         """
         raise NotImplementedError
 
-
     @abstractmethod
     async def setup_rate_limiter(self, **kwargs: Any) -> None:
         """Abstract method to set up the rate limiter.
 
         Args:
             **kwargs (Any): Additional keyword arguments.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_rate_limiter(self, key: str) -> Any:
+        """Abstract method to get a rate limiter by key path.
+
+        Args:
+            key: The keys to navigate to the rate limiter (e.g., "message" or "admin", "chatbot").
+
+        Returns:
+            Any: The requested rate limiter instance.
         """
         raise NotImplementedError

--- a/python/glchat-plugin/glchat_plugin/service/base_rate_limiter_service.py
+++ b/python/glchat-plugin/glchat_plugin/service/base_rate_limiter_service.py
@@ -1,0 +1,37 @@
+"""Provides a base class for rate limiter service.
+
+Authors:
+    Kevin Susanto (kevin.susanto@gdplabs.id)
+
+References:
+    NONE
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class BaseRateLimiterService(ABC):
+    """A base class for tenant service."""
+
+    @abstractmethod
+    async def custom_identifier(self, **kwargs: Any) -> str:
+        """Abstract method to get a custom identifier for rate limiting.
+
+        Args:
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+            str: A custom identifier for rate limiting.
+        """
+        raise NotImplementedError
+
+
+    @abstractmethod
+    async def setup_rate_limiter(self, **kwargs: Any) -> None:
+        """Abstract method to set up the rate limiter.
+
+        Args:
+            **kwargs (Any): Additional keyword arguments.
+        """
+        raise NotImplementedError


### PR DESCRIPTION
This pull request introduces a new abstract base class to standardize rate limiter services in the codebase. The new class defines the required interface for implementing custom rate limiter logic, ensuring consistency across different implementations.

New base class for rate limiter services:

* Added `BaseRateLimiterService` abstract base class in `glchat_plugin/service/base_rate_limiter_service.py`, defining two required async methods: `custom_identifier` for generating a rate limiting identifier, and `setup_rate_limiter` for initializing the rate limiter.